### PR TITLE
Show reload button when IndexedDB deletion is blocked

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -71,6 +71,8 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 function RemoveDB() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  const [showReloadButton, setShowReloadButton] = useState(false);
+
   const removeDB = useCallback(async () => {
     if (typeof window !== "undefined" && "indexedDB" in window) {
       try {
@@ -86,8 +88,9 @@ function RemoveDB() {
           setErrorMessage(errorMessage);
         };
         request.onblocked = () => {
+          setShowReloadButton(true);
           const errorMessage =
-            "Database deletion blocked - close other tabs using this site";
+            "Database deletion blocked - close other tabs using this site. If this site is not open in other tabs, try refreshing the page.";
           setErrorMessage(errorMessage);
           console.warn(errorMessage);
         };
@@ -110,6 +113,17 @@ function RemoveDB() {
         <RotateCwIcon /> Reset the db
       </Button>
       <p className="text-destructive font-bold text-center">{errorMessage}</p>
+      {showReloadButton && (
+        <Button
+          className="mx-auto"
+          variant="outline"
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          Reload page
+        </Button>
+      )}
     </ClientOnly>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when database operations are blocked due to concurrent activity in other browser tabs
  * Added "Reload page" button to help users quickly resolve database conflicts
  * Enhanced error messages with clearer guidance on recovery actions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->