### PR TITLE
Add a button to copy the currently viewed article's link

### DIFF
--- a/src/components/tutorial/TutorialWindow.tsx
+++ b/src/components/tutorial/TutorialWindow.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { steps as articles } from "@/data/tutorial";
 import { useScrollShadow } from "@/hooks/use-scroll-shadow";
 import { cn } from "@/lib/utils";
@@ -21,7 +22,6 @@ import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { ScrollShadow } from "../ui/scroll-shadow";
 import { TutorialTableOfContents } from "./TutorialTableOfContents";
-import { toast } from "sonner";
 
 function CopyArticleLinkButton({ activeStep }: { activeStep: string | null }) {
   const [copied, setCopied] = useState(false);

--- a/src/components/tutorial/TutorialWindow.tsx
+++ b/src/components/tutorial/TutorialWindow.tsx
@@ -21,6 +21,7 @@ import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { ScrollShadow } from "../ui/scroll-shadow";
 import { TutorialTableOfContents } from "./TutorialTableOfContents";
+import { toast } from "sonner";
 
 function CopyArticleLinkButton({ activeStep }: { activeStep: string | null }) {
   const [copied, setCopied] = useState(false);
@@ -34,10 +35,15 @@ function CopyArticleLinkButton({ activeStep }: { activeStep: string | null }) {
       encodeURIComponent(activeStep.toLowerCase()),
     );
 
-    navigator.clipboard.writeText(url.toString()).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    navigator.clipboard
+      .writeText(url.toString())
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((_) => {
+        toast.error("Couldn't copy the url");
+      });
   }, [activeStep]);
 
   return (

--- a/src/components/tutorial/TutorialWindow.tsx
+++ b/src/components/tutorial/TutorialWindow.tsx
@@ -1,6 +1,6 @@
 import { Tabs, TabsContent } from "@radix-ui/react-tabs";
 import { useNavigate, useRouter, useSearch } from "@tanstack/react-router";
-import { DatabaseZapIcon, XIcon } from "lucide-react";
+import { CheckIcon, DatabaseZapIcon, LinkIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import {
   useCallback,
@@ -21,6 +21,60 @@ import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { ScrollShadow } from "../ui/scroll-shadow";
 import { TutorialTableOfContents } from "./TutorialTableOfContents";
+
+function CopyArticleLinkButton({ activeStep }: { activeStep: string | null }) {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = useCallback(() => {
+    if (!activeStep) return;
+
+    const url = new URL(window.location.href);
+    url.searchParams.set(
+      "article",
+      encodeURIComponent(activeStep.toLowerCase()),
+    );
+
+    navigator.clipboard.writeText(url.toString()).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [activeStep]);
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={copyLink}
+      className="absolute top-2 right-4 z-20"
+      title="Copy link to this article"
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {copied ? (
+          <motion.div
+            key="check"
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.5, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+          >
+            <CheckIcon className="h-4 w-4 text-green-600" />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="link"
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.5, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+          >
+            <LinkIcon className="h-4 w-4" />
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {copied ? "Copied!" : "Copy link"}
+    </Button>
+  );
+}
 
 function FloatingWindowHeader({ toggleWindow }: { toggleWindow: () => void }) {
   return (
@@ -365,6 +419,7 @@ function FloatingWindow({
               isResizing && "pointer-events-none",
             )}
           >
+            <CopyArticleLinkButton activeStep={activeStep} />
             <ScrollShadow
               position="top"
               visible={canScrollUp}

--- a/src/components/tutorial/TutorialWindow.tsx
+++ b/src/components/tutorial/TutorialWindow.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { steps } from "@/data/tutorial";
+import { steps as articles } from "@/data/tutorial";
 import { useScrollShadow } from "@/hooks/use-scroll-shadow";
 import { cn } from "@/lib/utils";
 import {
@@ -379,7 +379,7 @@ function FloatingWindow({
                 isResizing ? "contain-strict" : "contain-none",
               )}
             >
-              {steps.map((step) => (
+              {articles.map((step) => (
                 <TabsContent
                   key={step.title}
                   value={step.title}
@@ -424,20 +424,26 @@ export function TutorialWindow({
 }) {
   const [isClosed, setIsClosed] = useState(tutorialData.isClosed);
 
-  const { step: activeStepFromSearch } = useSearch({ strict: false });
+  const { article: activeArticleFromSearch } = useSearch({ strict: false });
 
   const [activeStep, setActiveStep] = useState(
-    tutorialData.tutorialStep || steps[0].title,
+    tutorialData.tutorialStep || articles[0].title,
   );
 
   useEffect(() => {
-    if (activeStepFromSearch && typeof activeStepFromSearch === "string") {
-      const stepInSearch = decodeURIComponent(activeStepFromSearch);
-      if (steps.find((step) => step.title === stepInSearch)) {
-        setActiveStep(stepInSearch);
+    if (
+      activeArticleFromSearch &&
+      typeof activeArticleFromSearch === "string"
+    ) {
+      const articleInSearch = decodeURIComponent(
+        activeArticleFromSearch.toLowerCase(),
+      );
+
+      if (articles.find((a) => a.title === articleInSearch)) {
+        setActiveStep(articleInSearch);
       }
     }
-  }, [activeStepFromSearch]);
+  }, [activeArticleFromSearch]);
 
   const router = useRouter();
 

--- a/src/components/tutorial/index.tsx
+++ b/src/components/tutorial/index.tsx
@@ -99,7 +99,7 @@ export function LinkToArticle({
   articleTitle: string;
 }) {
   const encodedTitle = useMemo(
-    () => encodeURIComponent(articleTitle),
+    () => encodeURIComponent(articleTitle.toLowerCase()),
     [articleTitle],
   );
 
@@ -107,7 +107,7 @@ export function LinkToArticle({
     <Link
       to="."
       search={{
-        step: encodedTitle,
+        article: encodedTitle,
       }}
       className="text-orange-500 underline hover:text-orange-600 transition-colors cursor-pointer"
     >

--- a/src/routes/_tutorial.tsx
+++ b/src/routes/_tutorial.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/_tutorial")({
   validateSearch: z
     .object({
       temp_db_missing: z.string().optional(),
-      step: z.string().optional(),
+      article: z.string().optional(),
     })
     .extend(highlightParamSchema.shape),
   loader: async () => {


### PR DESCRIPTION
- **Rename a query param**
- **Add a button to copy the currently viewed article's link**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard button for article links with visual confirmation, integrated near article content.

* **Improvements**
  * Switched tutorial navigation to use an "article" query parameter instead of "step".
  * Article link encoding now lowercases titles before URL encoding for consistent sharing.
  * Updated tutorial flow and URL handling to use article-based parameters throughout without changing public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->